### PR TITLE
Allow to specify upload mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |
+      - name: Create file
+        run: |
           echo "Hello" > file.txt
-      - uses: ./
+      - name: Upload file on Dropbox
+        uses: ./
         with:
           dropbox_access_token: ${{ secrets.DROPBOX_ACCESS_TOKEN }}
           file: file.txt
           path: /test/my-file.txt
+      - name: Update file
+        run: |
+          echo "Hello updated" > file.txt
+      - name: Overwrite file on Dropbox
+        uses: ./
+        with:
+          dropbox_access_token: ${{ secrets.DROPBOX_ACCESS_TOKEN }}
+          file: file.txt
+          path: /test/my-file.txt
+          mode: overwrite

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
   path:
     required: true
     description: "Destination path for upload"
+  mode:
+    required: false
+    default: "add"
+    description: "Upload mode: [add, overwrite]. default: add"
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,12 +5,13 @@ import { upload } from './upload'
 const accessToken = core.getInput('dropbox_access_token')
 const file = core.getInput('file')
 const path = core.getInput('path')
+const mode = core.getInput('mode')
 
 async function run() {
   try {
     const contents = await fs.promises.readFile(file)
     core.debug(`Uploading '${file}' -> '${path}'`)
-    await upload(path, contents, accessToken)
+    await upload(path, contents, accessToken, mode)
     core.info(`'${file}' -> '${path}' has been successfully uploaded`)
   } catch (error) {
     core.setFailed(error)

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -4,8 +4,25 @@ import fetch from 'node-fetch'
 export async function upload(
   path: string,
   contents: Buffer,
-  accessToken: string
+  accessToken: string,
+  dropboxMode: string
 ): Promise<void> {
+  const mode = getMode(dropboxMode)
+
   const dropbox = new Dropbox({ accessToken, fetch })
-  await dropbox.filesUpload({ path, contents })
+  await dropbox.filesUpload({ path, contents, mode })
+}
+
+function getMode(mode: string): DropboxTypes.files.WriteMode {
+  switch (mode) {
+    case 'overwrite':
+      return {
+        '.tag': 'overwrite',
+      }
+    case 'add':
+    default:
+      return {
+        '.tag': 'add',
+      }
+  }
 }


### PR DESCRIPTION
Recently I tried to use this action to upload a file to my dropbox.
Though the file is always named the same which leads to an error on upload:
```
Error: {"error":{"error_summary":"path/conflict/file/..","error":{".tag":"path","reason":{".tag":"conflict","conflict":{".tag":"file"}},"upload_session_id":"****"}},"response":{"size":0,"timeout":0},"status":409}
```

I'm not really familiar with Typescript but I tried to add an option to send the parameter `mode` on file upload. This will allow to set it to `overwrite` to upload the new file over the old one.

As a side note there's a 3rd mode called `update` that is available (and safer) but it requires the `rev` that we don't have.

I don't really know if you're interested to add this feature or not so feel free to modify it as you wish (you should be able to do edits) or close it.